### PR TITLE
Update node version for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
GitHub was throwing an error because the node version format was deprecated